### PR TITLE
Factor out variable ‘baseURL’ in OpenAISDK

### DIFF
--- a/OpenAI/OpenAISDK.class.st
+++ b/OpenAI/OpenAISDK.class.st
@@ -23,6 +23,7 @@ Class {
 	#name : #OpenAISDK,
 	#superclass : #Object,
 	#instVars : [
+		'baseURL',
 		'client'
 	],
 	#category : #'OpenAI-Core'
@@ -57,9 +58,16 @@ OpenAISDK class >> openUsagePage [
 	WebBrowser openOn: 'https://platform.openai.com/account/usage'
 ]
 
-{ #category : #private }
-OpenAISDK >> baseURL [ 
-^ 'https://api.openai.com/v1'
+{ #category : #accessing }
+OpenAISDK >> baseURL [
+
+	^ baseURL ifNil: [ 'https://api.openai.com/v1' ]
+]
+
+{ #category : #accessing }
+OpenAISDK >> baseURL: anObject [
+
+	baseURL := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This pull request factors out a variable for ‘baseURL’ in OpenAISDK so that a [‘llama.cpp’](https://github.com/ggerganov/llama.cpp) server can be used. For example:

```smalltalk
((OpenAIChatSession startWithSDK:
	((OpenAISDK createWithAPIKey: 'APIKey123')
		baseURL: 'http://localhost:8000/v1';
		yourself))
	submitUserPrompt: 'Briefly introduce yourself';
	lastChat) content
"⇒ 'Nice to meet you! I''m LLaMA, a large language model trained by […]'"
```

The following shell command downloads a model and runs the server using Docker (wait for it to output a line saying ‘HTTP server listening’):

```shell
curl --location \
	--output Meta-Llama-3-8B-Instruct.Q3_K_M.gguf \
	--etag-save Meta-Llama-3-8B-Instruct.Q3_K_M.gguf.etag \
	--etag-compare Meta-Llama-3-8B-Instruct.Q3_K_M.gguf.etag \
	https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct.Q3_K_M.gguf \
&& docker run \
	--volume ./Meta-Llama-3-8B-Instruct.Q3_K_M.gguf:/models/Meta-Llama-3-8B-Instruct.Q3_K_M.gguf:ro \
	--publish 8000:8000 \
	ghcr.io/ggerganov/llama.cpp:server \
	--model /models/Meta-Llama-3-8B-Instruct.Q3_K_M.gguf \
	--port 8000 \
	--host 0.0.0.0 \
	--api-key APIKey123
```