### PR TITLE
deal with missing values in response while keeping instvars in OpenAI…

### DIFF
--- a/OpenAI/OpenAISDKModel.class.st
+++ b/OpenAI/OpenAISDKModel.class.st
@@ -37,9 +37,9 @@ OpenAISDKModel class >> createWithAPIResponse: aResponse [
 
 	^ self new
 		  ownedBy: (aResponse at: 'owned_by');
-		  parent: (aResponse at: 'parent');
-		  root: (aResponse at: 'root');
-		  permission: (aResponse at: 'permission');
+		  parent: (aResponse at: 'parent' ifAbsent: nil);
+		  root: (aResponse at: 'root' ifAbsent: nil);
+		  permission: (aResponse at: 'permission' ifAbsent: nil);
 		  created: (aResponse at: 'created');
 		  object: (aResponse at: 'object');
 		  id: (aResponse at: 'id')


### PR DESCRIPTION
An attempt to fix or find a workaround to #3 
Keep instance variables for root, parent and permissions in OpenAISDKModel
Set them to nil if the response from the API does not have values for those attributes 